### PR TITLE
Initializing Variables in evaluateVariables stage

### DIFF
--- a/provider/pipeline_evaluate_variables_stage.go
+++ b/provider/pipeline_evaluate_variables_stage.go
@@ -14,6 +14,7 @@ type evaluateVariablesStage struct {
 func newEvaluateVariablesStage() *evaluateVariablesStage {
 	return &evaluateVariablesStage{
 		baseStage: *newBaseStage(),
+		Variables: make(map[string]string),
 	}
 }
 


### PR DESCRIPTION
I've encountered this issue :
> "0b1e539b-1ea3-49c8-9f89-a0323bfdcc40"],"restrictExecutionDuringTimeWindow":false,"sendNotifications":false,"type":"evaluateVariables","variables":[{"key":"ami","value":"${#stage('Fetch AMI list')['context']['webhook']['body'].split('\\n').?[contains('amd64') && contains('ebs-ssd') && contains('us-east-1')][0].split('\\t')[7]}"}]}],"disabled":false,"id":"xxxxx","updateTs":"1590570852000"}]
> 
> Error: rpc error: code = Unavailable desc = transport is closing
> 
> Error: rpc error: code = Unavailable desc = transport is closing
> 
> 
> Releasing state lock. This may take a few moments...
>  assignment to entry in nil map
